### PR TITLE
Abort if nightly doesn't produce data.json

### DIFF
--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -23,8 +23,17 @@ def run_cmd(cmd, msg = "", dry_run = False):
     subprocess.run(cmd, check = True)
 
 def run_poach(in_dir, out_dir, run_mode):
-  poach_exe = top_dir / "target" / "release" / "poach"
-  run_cmd([str(poach_exe), str(in_dir), str(out_dir), run_mode])
+  run_cmd([
+    "cargo",
+    "run",
+    "--release",
+    "--bin",
+    "poach",
+    "--",
+    str(in_dir),
+    str(out_dir),
+    run_mode
+  ])
 
 if __name__ == "__main__":
   print("Beginning poach nightly")

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -48,8 +48,8 @@ cargo build --release
 python3 infra/nightly.py
 
 # Abort if nightly.py failed to produce data.json
-if [ ! -f nightly/output/data.json ]; then
-  echo "ERROR: nightly/output/data.json was not generated."
+if [ ! -f nightly/output/data/data.json ]; then
+  echo "ERROR: nightly/output/data/data.json was not generated."
   exit 1
 fi
 


### PR DESCRIPTION
So nightly has been silently failing for a few days because of the memory cap (fixed by https://github.com/uwplse/nightly-conf/pull/45), because we were producing the report and everything, but the data.json was not present, so the page was just not showing anything.

We should abort if data.json doesn't exist so that the nightly will show as failed in #poach-notify.

Also has two small cleanups:
1. the generate flamegraphs code was duplicated, probably my fault on a merge or something
2. use `cargo run ...` instead of running the built executable because it shows up nicer in the logs.