### PR TITLE
Reporting Changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod constraint;
 mod core;
 pub mod extract;
 pub mod prelude;
+pub mod report;
 pub mod scheduler;
 mod serialize;
 pub mod sort;
@@ -1561,6 +1562,37 @@ impl EGraph {
     /// Return a list of messages.
     pub fn run_program(&mut self, program: Vec<Command>) -> Result<Vec<CommandOutput>, Error> {
         let (outputs, _desugared_commands) = self.process_program_internal(program, true)?;
+        Ok(outputs)
+    }
+
+    pub fn run_program_with_reporter(
+        &mut self,
+        program: Vec<Command>,
+        reporter: &mut report::Reporter,
+    ) -> Result<Vec<CommandOutput>, Error> {
+        let mut outputs = Vec::new();
+
+        // No support for macros or includes yet
+        for command in program {
+            for processed in self.resolve_command(command)? {
+                let command_name = processed.to_command().to_string();
+                let command_category = match &processed {
+                    ResolvedNCommand::RunSchedule(_) => "running_rules",
+                    ResolvedNCommand::Extract(_, _, _)
+                    | ResolvedNCommand::MultiExtract(_, _, _) => "extraction",
+                    ResolvedNCommand::Check(_, _) => "check",
+                    _ => "other",
+                };
+                let timer = std::time::Instant::now();
+                let result = self.run_command(processed)?;
+                let elapsed = timer.elapsed();
+                reporter.record_timing(command_name, vec![command_category.to_string()], elapsed);
+                if let Some(output) = result {
+                    outputs.push(output);
+                }
+            }
+        }
+
         Ok(outputs)
     }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 #[derive(Default)]
 pub struct Reporter {
-    spans: HashMap<String, SpanStats>,
+    spans: HashMap<(String, Vec<String>), SpanStats>,
     sizes: Vec<SizeMetric>,
 }
 
@@ -39,6 +39,7 @@ pub struct TimingReport {
 #[derive(Serialize)]
 struct TimingStep {
     name: String,
+    tags: Vec<String>,
     count: u64,
     #[serde(with = "serde_millis")]
     total: Duration,
@@ -69,19 +70,22 @@ impl Reporter {
     }
 
     pub fn finish_timer(&mut self, timer: Timer) {
-        self.record_span_time(&timer.name, timer.started_at.elapsed());
+        self.record_span_time(&timer.name, &[], timer.started_at.elapsed());
     }
 
     pub fn record_size(&mut self, name: String, value: MetricValue) {
         self.sizes.push(SizeMetric { name, value });
     }
 
-    pub fn record_timing(&mut self, name: String, elapsed: Duration) {
-        self.record_span_time(&name, elapsed);
+    pub fn record_timing(&mut self, name: String, tags: Vec<String>, elapsed: Duration) {
+        self.record_span_time(&name, &tags, elapsed);
     }
 
-    fn record_span_time(&mut self, name: &str, elapsed: Duration) {
-        let entry = self.spans.entry(name.to_owned()).or_default();
+    fn record_span_time(&mut self, name: &str, tags: &[String], elapsed: Duration) {
+        let entry = self
+            .spans
+            .entry((name.to_owned(), tags.to_vec()))
+            .or_default();
         entry.count += 1;
         entry.total += elapsed;
     }
@@ -90,9 +94,10 @@ impl Reporter {
         let mut steps: Vec<_> = self
             .spans
             .iter()
-            .filter(|(name, _)| name.as_str() != "command")
-            .map(|(name, stats)| TimingStep {
+            .filter(|((name, _), _)| name.as_str() != "command")
+            .map(|((name, tags), stats)| TimingStep {
                 name: name.clone(),
+                tags: tags.clone(),
                 count: stats.count,
                 total: stats.total,
             })
@@ -104,7 +109,7 @@ impl Reporter {
             timing: TimingReport {
                 total: self
                     .spans
-                    .get("command")
+                    .get(&("command".to_string(), vec![]))
                     .map(|stats| stats.total)
                     .unwrap_or_default(),
                 steps,
@@ -139,10 +144,16 @@ impl Display for TimingReport {
             } else {
                 Duration::from_secs_f64(step.total.as_secs_f64() / step.count as f64)
             };
+            let tag_display = if step.tags.is_empty() {
+                "untagged".to_string()
+            } else {
+                step.tags.join(",")
+            };
             writeln!(
                 f,
-                "    {}: total={}, count={}, avg={}",
+                "    {} [{}]: total={}, count={}, avg={}",
                 step.name,
+                tag_display,
                 step.total.as_secs_f64(),
                 step.count,
                 avg.as_secs_f64(),


### PR DESCRIPTION
Needed for the Vanilla Egglog nightly report, but likely generally useful, so I think it makes sense to merge into PTP

- add a list of tags to each TimingStep, which gets used to aggregate rules, extract, and check commands
- Add a way to run a list of commands and record timing of each step