### PR TITLE
Use poach-benchmarks for nightly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 ## Conventions + Style
 
 - Avoid defensive code that adds complexity without a clear, likely payoff.
+- Avoid introducing local variables that are only used once or twice when inlining keeps the code clear.
 
 ## Response format
 

--- a/infra/nightly-resources/web/index.html
+++ b/infra/nightly-resources/web/index.html
@@ -17,6 +17,8 @@
         </div>
         <div id="benchmarks">
           <h2>Reports</h2>
+          <div id="suite-tabs"></div>
+          <div id="active-suite-summary"></div>
           <table>
             <thead>
               <tr>

--- a/infra/nightly-resources/web/index.js
+++ b/infra/nightly-resources/web/index.js
@@ -1,10 +1,12 @@
 import { formatMillis } from "./util.js";
 
-const statusNode = document.querySelector("#status");
-
+let suites = [];
+let activeSuiteName = null;
 load();
 
 async function load() {
+  const statusNode = document.querySelector("#status");
+
   try {
     const response = await fetch("./data/data.json");
     if (!response.ok) {
@@ -12,9 +14,11 @@ async function load() {
     }
 
     const data = await response.json();
+    suites = data.suites;
+    activeSuiteName = suites[0]?.name ?? null;
     statusNode.textContent = "Loaded data/data.json";
     renderSummary(data);
-    renderBenchmarks(data.reports);
+    renderSuites();
   } catch (error) {
     statusNode.textContent = `Failed to load data/data.json: ${error}`;
   }
@@ -32,19 +36,59 @@ function renderSummary(data) {
   }
 
   document.querySelector("#summary-text").textContent =
-    `${data.reports.length} benchmarks | ` +
+    `${data.summary.benchmark_count} benchmarks across ${data.suites.length} suites | ` +
     `Nightly time: ${data.summary.total_time_seconds.toFixed(1)} s | ` +
     `Rule running: ${ruleRunningMillis} ms | ` +
     `Extraction: ${extractionMillis} ms | ` +
     `Other: ${otherMillis} ms`;
 }
 
-function renderBenchmarks(reports) {
-  document.querySelector("#benchmarks-body").innerHTML = reports
-    .map(({ path, time_seconds, timing_summary }) => {
+function renderSuites() {
+  document.querySelector("#suite-tabs").innerHTML = suites
+    .map((suite) => {
+      return `
+        <button
+          type="button"
+          class="suite-tab${suite.name === activeSuiteName ? " is-active" : ""}"
+          data-suite-name="${suite.name}"
+        >
+          ${suite.name}
+        </button>
+      `;
+    })
+    .join("");
+
+  for (const button of document.querySelectorAll(".suite-tab")) {
+    button.addEventListener("click", () => {
+      activeSuiteName = button.dataset.suiteName;
+      renderSuites();
+    });
+  }
+
+  const activeSuite = suites.find((suite) => suite.name === activeSuiteName);
+  if (!activeSuite) {
+    document.querySelector("#active-suite-summary").textContent = "";
+    document.querySelector("#benchmarks-body").innerHTML = "";
+    return;
+  }
+
+  document.querySelector("#active-suite-summary").innerHTML = `
+    <div class="suite-header">
+      <h3>${activeSuite.name}</h3>
+      <p>${activeSuite.reports.length} benchmarks | ${activeSuite.summary.total_time_seconds.toFixed(1)} s</p>
+    </div>
+  `;
+  document.querySelector("#benchmarks-body").innerHTML = renderRows(
+    activeSuite.reports,
+  );
+}
+
+function renderRows(reports) {
+  return reports
+    .map(({ benchmark_path, time_seconds, timing_summary }) => {
       return `
         <tr>
-          <td>${path}</td>
+          <td>${benchmark_path}</td>
           <td>${time_seconds.toFixed(3)} s</td>
           <td>${formatMillis(timing_summary.rule_running_millis)}</td>
           <td>${formatMillis(timing_summary.extraction_millis)}</td>

--- a/infra/nightly-resources/web/index.js
+++ b/infra/nightly-resources/web/index.js
@@ -25,11 +25,10 @@ function renderSummary(data) {
   let extractionMillis = 0;
   let otherMillis = 0;
 
-  for (const { report } of data.reports) {
-    const totals = getTimingTotals(report);
-    ruleRunningMillis += totals.ruleRunningMillis;
-    extractionMillis += totals.extractionMillis;
-    otherMillis += totals.otherMillis;
+  for (const { timing_summary } of data.reports) {
+    ruleRunningMillis += timing_summary.rule_running_millis;
+    extractionMillis += timing_summary.extraction_millis;
+    otherMillis += timing_summary.other_millis;
   }
 
   document.querySelector("#summary-text").textContent =
@@ -42,37 +41,17 @@ function renderSummary(data) {
 
 function renderBenchmarks(reports) {
   document.querySelector("#benchmarks-body").innerHTML = reports
-    .map(({ path, time_seconds, report }) => {
-      const totals = getTimingTotals(report);
-
+    .map(({ path, time_seconds, timing_summary }) => {
       return `
         <tr>
           <td>${path}</td>
           <td>${time_seconds.toFixed(3)} s</td>
-          <td>${formatMillis(totals.ruleRunningMillis)}</td>
-          <td>${formatMillis(totals.extractionMillis)}</td>
-          <td>${formatMillis(totals.otherMillis)}</td>
-          <td>${report.timings.length}</td>
+          <td>${formatMillis(timing_summary.rule_running_millis)}</td>
+          <td>${formatMillis(timing_summary.extraction_millis)}</td>
+          <td>${formatMillis(timing_summary.other_millis)}</td>
+          <td>${timing_summary.timing_steps}</td>
         </tr>
       `;
     })
     .join("");
-}
-
-function getTimingTotals(report) {
-  let ruleRunningMillis = 0;
-  let extractionMillis = 0;
-  let otherMillis = 0;
-
-  for (const timing of report.timings) {
-    if (timing.tags.includes("running_rules")) {
-      ruleRunningMillis += timing.total;
-    } else if (timing.tags.includes("extraction")) {
-      extractionMillis += timing.total;
-    } else {
-      otherMillis += timing.total;
-    }
-  }
-
-  return { ruleRunningMillis, extractionMillis, otherMillis };
 }

--- a/infra/nightly-resources/web/style.css
+++ b/infra/nightly-resources/web/style.css
@@ -31,6 +31,44 @@ h1 {
   margin: 0 0 16px;
 }
 
+.suite {
+  margin: 0 0 24px;
+}
+
+.suite-tab {
+  appearance: none;
+  border: 1px solid #ccc;
+  background: #f0f0f0;
+  color: inherit;
+  padding: 8px 12px;
+  margin: 0 8px 12px 0;
+  font: inherit;
+  cursor: pointer;
+}
+
+.suite-tab.is-active {
+  background: #111;
+  border-color: #111;
+  color: #fff;
+}
+
+.suite-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 0 8px;
+}
+
+.suite-header p {
+  margin: 0;
+}
+
+h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
 h2 {
   margin: 0 0 8px;
   font-size: 1.1rem;

--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -30,7 +30,7 @@ def main() -> None:
     benchmark_dirs = list(
         path
         for path in benchmark_root.iterdir()
-        if path.is_dir() and any(path.rglob("*.egg"))
+        if path.is_dir() and any((path / "train").glob("*.egg"))
     )
     if not benchmark_dirs:
         raise SystemExit(f"No benchmark suite directories found under {benchmark_root}.")
@@ -79,7 +79,7 @@ def run_benchmarks(benchmark_dirs: list[Path]) -> list[dict[str, Any]]:
     benchmark_root = benchmark_dirs[0].parent
     results = []
     for benchmark_dir in benchmark_dirs:
-        benchmark_files = list(benchmark_dir.rglob("*.egg"))
+        benchmark_files = list((benchmark_dir / "train").glob("*.egg"))
         for benchmark_file in benchmark_files:
             report_path = REPORT_OUTPUT_DIR / benchmark_file.relative_to(
                 benchmark_root

--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -93,6 +93,27 @@ def run_benchmarks(benchmark_dir: Path) -> list[dict[str, Any]]:
     return results
 
 
+def summarize_report(report: dict[str, Any]) -> dict[str, int]:
+    rule_running_millis = 0
+    extraction_millis = 0
+    other_millis = 0
+
+    for timing in report["timings"]:
+        if "running_rules" in timing["tags"]:
+            rule_running_millis += timing["total"]
+        elif "extraction" in timing["tags"]:
+            extraction_millis += timing["total"]
+        else:
+            other_millis += timing["total"]
+
+    return {
+        "rule_running_millis": rule_running_millis,
+        "extraction_millis": extraction_millis,
+        "other_millis": other_millis,
+        "timing_steps": len(report["timings"]),
+    }
+
+
 def aggregate_reports(
     benchmark_dir: Path, command_results: list[dict[str, Any]]
 ) -> dict[str, Any]:
@@ -109,7 +130,6 @@ def aggregate_reports(
             else str(benchmark_dir)
         ),
         "summary": {
-            "commands": command_results,
             "total_time_seconds": sum(
                 result["time_seconds"] for result in command_results
             ),
@@ -118,7 +138,11 @@ def aggregate_reports(
             {
                 "path": str(Path(result["report_path"]).relative_to(OUTPUT_DIR)),
                 "time_seconds": result["time_seconds"],
-                "report": json.loads(Path(result["report_path"]).read_text(encoding="utf-8")),
+                "timing_summary": summarize_report(
+                    json.loads(
+                        Path(result["report_path"]).read_text(encoding="utf-8")
+                    )
+                ),
             }
             for result in command_results
         ],

--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -26,16 +26,17 @@ def main() -> None:
     if len(sys.argv) != 2:
         raise SystemExit(f"Usage: {Path(sys.argv[0]).name} <benchmark-dir>")
 
-    benchmark_dir = (REPO_ROOT / sys.argv[1]).resolve()
+    benchmark_root = (REPO_ROOT / sys.argv[1]).resolve()
+    benchmark_dirs = list(
+        path
+        for path in benchmark_root.iterdir()
+        if path.is_dir() and any(path.rglob("*.egg"))
+    )
+    if not benchmark_dirs:
+        raise SystemExit(f"No benchmark suite directories found under {benchmark_root}.")
 
-    benchmark_files = list(benchmark_dir.rglob("*.egg"))
-    if not benchmark_files:
-        raise SystemExit(
-            f"No .egg benchmark files found under {benchmark_dir}."
-        )
-
-    command_results = run_benchmarks(benchmark_dir)
-    data = aggregate_reports(benchmark_dir, command_results)
+    benchmark_results = run_benchmarks(benchmark_dirs)
+    data = aggregate_reports(benchmark_dirs, benchmark_results)
 
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     DATA_JSON_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
@@ -70,26 +71,32 @@ def run_command(command: list[str], *, cwd: Path, report_path: Path) -> dict[str
         "time_seconds": time.perf_counter() - started,
     }
 
-
-def run_benchmarks(benchmark_dir: Path) -> list[dict[str, Any]]:
+def run_benchmarks(benchmark_dirs: list[Path]) -> list[dict[str, Any]]:
     if REPORT_OUTPUT_DIR.exists():
         shutil.rmtree(REPORT_OUTPUT_DIR)
     REPORT_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
+    benchmark_root = benchmark_dirs[0].parent
     results = []
-    for benchmark_file in benchmark_dir.rglob("*.egg"):
-        relative_benchmark = benchmark_file.relative_to(benchmark_dir)
-        report_path = REPORT_OUTPUT_DIR / relative_benchmark.with_suffix(".report.json")
-        command = [
-            str(POACH_BIN),
-            "serve",
-            "--debug",
-            str(MODEL_FILE),
-            "single",
-            str(benchmark_file),
-        ]
-        print("Running benchmark:", " ".join(command))
-        results.append(run_command(command, cwd=REPO_ROOT, report_path=report_path))
+    for benchmark_dir in benchmark_dirs:
+        benchmark_files = list(benchmark_dir.rglob("*.egg"))
+        for benchmark_file in benchmark_files:
+            report_path = REPORT_OUTPUT_DIR / benchmark_file.relative_to(
+                benchmark_root
+            ).with_suffix(".report.json")
+            command = [
+                str(POACH_BIN),
+                "serve",
+                "--debug",
+                str(MODEL_FILE),
+                "single",
+                str(benchmark_file),
+            ]
+            print("Running benchmark:", " ".join(command))
+            result = run_command(command, cwd=REPO_ROOT, report_path=report_path)
+            result["suite"] = benchmark_dir.name
+            result["benchmark_path"] = str(benchmark_file.relative_to(benchmark_dir))
+            results.append(result)
     return results
 
 
@@ -115,37 +122,58 @@ def summarize_report(report: dict[str, Any]) -> dict[str, int]:
 
 
 def aggregate_reports(
-    benchmark_dir: Path, command_results: list[dict[str, Any]]
+    benchmark_dirs: list[Path], benchmark_results: list[dict[str, Any]]
 ) -> dict[str, Any]:
-    report_files = list(REPORT_OUTPUT_DIR.rglob("*.report.json"))
-    if not report_files:
+    if not benchmark_results:
         raise SystemExit(f"No report files were generated under {REPORT_OUTPUT_DIR}")
+
+    benchmark_root = benchmark_dirs[0].parent
+    suites = []
+    for benchmark_dir in benchmark_dirs:
+        suite_results = [
+            result for result in benchmark_results if result["suite"] == benchmark_dir.name
+        ]
+        suites.append(
+            {
+                "name": benchmark_dir.name,
+                "benchmark_root": str(benchmark_dir.relative_to(REPO_ROOT)),
+                "summary": {
+                    "total_time_seconds": sum(
+                        result["time_seconds"] for result in suite_results
+                    ),
+                },
+                "reports": [
+                    {
+                        "suite": benchmark_dir.name,
+                        "benchmark_path": result["benchmark_path"],
+                        "path": str(
+                            Path(result["report_path"]).relative_to(OUTPUT_DIR)
+                        ),
+                        "time_seconds": result["time_seconds"],
+                        "timing_summary": summarize_report(
+                            json.loads(
+                                Path(result["report_path"]).read_text(
+                                    encoding="utf-8"
+                                )
+                            )
+                        ),
+                    }
+                    for result in suite_results
+                ],
+            }
+        )
 
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(),
-        "suite": benchmark_dir.name,
-        "benchmark_root": (
-            str(benchmark_dir.relative_to(REPO_ROOT))
-            if benchmark_dir.is_absolute()
-            else str(benchmark_dir)
-        ),
+        "benchmark_root": str(benchmark_root.relative_to(REPO_ROOT)),
         "summary": {
+            "benchmark_count": len(benchmark_results),
             "total_time_seconds": sum(
-                result["time_seconds"] for result in command_results
+                result["time_seconds"] for result in benchmark_results
             ),
         },
-        "reports": [
-            {
-                "path": str(Path(result["report_path"]).relative_to(OUTPUT_DIR)),
-                "time_seconds": result["time_seconds"],
-                "timing_summary": summarize_report(
-                    json.loads(
-                        Path(result["report_path"]).read_text(encoding="utf-8")
-                    )
-                ),
-            }
-            for result in command_results
-        ],
+        "suites": suites,
+        "reports": [report for suite in suites for report in suite["reports"]],
     }
 
 

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -20,14 +20,15 @@ rm -rf nightly
 mkdir -p nightly/output
 mkdir -p nightly/tmp
 
-# TODO: use real benchmarks
-# git clone https://github.com/ajpal/poach-benchmarks.git
+BENCHMARKS_DIR="nightly/tmp/poach-benchmarks"
+
+git clone https://github.com/ajpal/poach-benchmarks.git "$BENCHMARKS_DIR"
 
 # Build in release mode before running nightly.py
 cargo build --release
 
 # This script runs all of the benchmarks/experiments
-python3 infra/nightly.py tests/passing
+python3 infra/nightly.py "$BENCHMARKS_DIR"
 
 # Abort if nightly.py failed to produce data.json. Without this check,
 # the nightly runner will report the nightly as successful even though the
@@ -40,4 +41,4 @@ fi
 cp infra/nightly-resources/web/* nightly/output
 
 # Uncomment for local development
-# cd nightly/output && python3 -m http.server 8002
+cd nightly/output && python3 -m http.server 8002

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 echo "Beginning POACH nightly script..."

--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -43,4 +43,4 @@ fi
 cp infra/nightly-resources/web/* nightly/output
 
 # Uncomment for local development
-cd nightly/output && python3 -m http.server 8002
+# cd nightly/output && python3 -m http.server 8002

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display, Formatter};
 use std::time::{Duration, Instant};
 
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 type TimerHandle = usize;
 
@@ -30,6 +30,7 @@ struct TimingStep {
     tags: Vec<String>,
     #[serde(with = "serde_millis")]
     total: Duration,
+    #[serde(serialize_with = "serialize_duration_breakdown")]
     breakdown: Vec<Duration>,
 }
 
@@ -109,9 +110,24 @@ impl Display for TimingStep {
         writeln!(f, "  name: {}", self.name)?;
         writeln!(f, "  tags: {:?}", self.tags)?;
         writeln!(f, "  total: {}", self.total.as_secs_f64())?;
-        writeln!(f, "  breakdown: {:?}", self.breakdown)?;
+        writeln!(
+            f,
+            "  breakdown: {:?}",
+            self.breakdown
+                .iter()
+                .map(Duration::as_millis)
+                .collect::<Vec<_>>()
+        )?;
         Ok(())
     }
+}
+
+fn serialize_duration_breakdown<S>(breakdown: &[Duration], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let breakdown_millis: Vec<_> = breakdown.iter().map(Duration::as_millis).collect();
+    breakdown_millis.serialize(serializer)
 }
 
 fn write_metric_section<T>(f: &mut Formatter<'_>, title: &str, metrics: &[T]) -> fmt::Result


### PR DESCRIPTION
- Make data.json smaller by aggregating timing info by tag on the backend
- Show table per-suite with toggle at the top

Nightly run
https://nightly.cs.washington.edu/reports/poach/1777481882:ajpal-nightly-benchmarks:f1979b31/