### PR TITLE
Better time displays

### DIFF
--- a/infra/nightly-resources/web/index.html
+++ b/infra/nightly-resources/web/index.html
@@ -9,6 +9,11 @@
   <body>
     <main class="page">
       <h1>Poach Nightly</h1>
+      <fieldset id="time-display-selector">
+        <legend>Time Display</legend>
+        <label><input type="radio" name="time-display" value="raw" checked /> Raw</label>
+        <label><input type="radio" name="time-display" value="readable" /> Readable</label>
+      </fieldset>
       <p id="status">Loading <code>data/data.json</code>...</p>
       <div id="contents">
         <div id="summary">

--- a/infra/nightly-resources/web/index.html
+++ b/infra/nightly-resources/web/index.html
@@ -11,8 +11,8 @@
       <h1>Poach Nightly</h1>
       <fieldset id="time-display-selector">
         <legend>Time Display</legend>
-        <label><input type="radio" name="time-display" value="raw" checked /> Raw</label>
-        <label><input type="radio" name="time-display" value="readable" /> Readable</label>
+        <label><input type="radio" name="time-display" value="readable" checked /> Readable</label>
+        <label><input type="radio" name="time-display" value="raw" /> Raw</label>
       </fieldset>
       <p id="status">Loading <code>data/data.json</code>...</p>
       <div id="contents">

--- a/infra/nightly-resources/web/index.js
+++ b/infra/nightly-resources/web/index.js
@@ -2,7 +2,7 @@ import { convertToTable } from "./table.js";
 
 const STATE = {
   activeSuite: null,
-  timeDisplay: "raw",
+  timeDisplay: "readable",
 };
 
 const GLOBAL_DATA = {

--- a/infra/nightly-resources/web/index.js
+++ b/infra/nightly-resources/web/index.js
@@ -34,29 +34,29 @@ async function load() {
 }
 
 function renderSummary() {
-  let ruleMs = 0;
-  let extractMs = 0;
-  let otherMs = 0;
+  let ruleMicros = 0;
+  let extractMicros = 0;
+  let otherMicros = 0;
 
   for (const reportSummary of GLOBAL_DATA.data.passing_benchmarks) {
-    ruleMs += reportSummary.report.rule_ms;
-    extractMs += reportSummary.report.extraction_ms;
-    otherMs += reportSummary.report.other_ms;
+    ruleMicros += reportSummary.report.rule_micros;
+    extractMicros += reportSummary.report.extraction_micros;
+    otherMicros += reportSummary.report.other_micros;
   }
 
   const numPassing = GLOBAL_DATA.data.passing_benchmarks.length;
   const numFailing = GLOBAL_DATA.data.failing_benchmarks.length;
   const totalTime = GLOBAL_DATA.data.passing_benchmarks
-    .map((x) => x.wall_time_s)
+    .map((x) => x.wall_time_micros)
     .reduce((a, b) => a + b, 0);
 
   document.querySelector("#summary-text").textContent =
     `Passing Benchmarks: ${numPassing} | ` +
     `Failing Benchmarks: ${numFailing} | ` +
-    `Nightly time: ${totalTime.toFixed(1)} s | ` +
-    `Rule running: ${(ruleMs / 1000).toFixed(1)} s | ` +
-    `Extraction: ${(extractMs / 1000).toFixed(1)} s | ` +
-    `Other: ${(otherMs / 1000).toFixed(1)} s`;
+    `Nightly time: ${totalTime} μs | ` +
+    `Rule running: ${ruleMicros} μs | ` +
+    `Extraction: ${extractMicros} μs | ` +
+    `Other: ${otherMicros} μs`;
 }
 
 function renderSuiteSelectors() {
@@ -95,7 +95,7 @@ function renderTable() {
     (x) => x.suite_name === STATE.activeSuite,
   );
   const totalTime = benchmarks
-    .map((x) => x.wall_time_s)
+    .map((x) => x.wall_time_micros)
     .reduce((a, b) => a + b, 0);
 
   document.querySelector("#active-suite-summary").innerHTML = `
@@ -106,18 +106,18 @@ function renderTable() {
 
   const columns = [
     "Benchmark",
-    "Wall Time (s)",
-    "Rules (ms)",
-    "Extraction (ms)",
-    "Other (ms)",
+    "Wall Time (μs)",
+    "Rules (μs)",
+    "Extraction (μs)",
+    "Other (μs)",
   ];
 
   const rows = benchmarks.map((b) => ({
     Benchmark: b.benchmark_name,
-    "Wall Time (s)": b.wall_time_s.toFixed(2),
-    "Rules (ms)": b.report.rule_ms,
-    "Extraction (ms)": b.report.extraction_ms,
-    "Other (ms)": b.report.other_ms,
+    "Wall Time (μs)": b.wall_time_micros,
+    "Rules (μs)": b.report.rule_micros,
+    "Extraction (μs)": b.report.extraction_micros,
+    "Other (μs)": b.report.other_micros,
   }));
 
   const tableDiv = document.querySelector("#active-suite-table");

--- a/infra/nightly-resources/web/index.js
+++ b/infra/nightly-resources/web/index.js
@@ -142,15 +142,22 @@ function renderTable() {
 
   const rows = benchmarks.map((b) => ({
     Benchmark: b.benchmark_name,
-    "Wall Time": displayTime(b.wall_time_micros),
-    Rules: displayTime(b.report.rule_micros),
-    Extraction: displayTime(b.report.extraction_micros),
-    Other: displayTime(b.report.other_micros),
+    "Wall Time": b.wall_time_micros,
+    Rules: b.report.rule_micros,
+    Extraction: b.report.extraction_micros,
+    Other: b.report.other_micros,
   }));
+
+  const displayFns = {
+    "Wall Time": displayTime,
+    Rules: displayTime,
+    Extraction: displayTime,
+    Other: displayTime,
+  };
 
   const tableDiv = document.querySelector("#active-suite-table");
   tableDiv.innerHTML = "";
-  tableDiv.appendChild(convertToTable(columns, rows));
+  tableDiv.appendChild(convertToTable(columns, rows, displayFns));
 }
 
 function render() {

--- a/infra/nightly-resources/web/index.js
+++ b/infra/nightly-resources/web/index.js
@@ -2,6 +2,7 @@ import { convertToTable } from "./table.js";
 
 const STATE = {
   activeSuite: null,
+  timeDisplay: "raw",
 };
 
 const GLOBAL_DATA = {
@@ -21,16 +22,49 @@ async function load() {
   }
 
   GLOBAL_DATA.data = await response.json();
+  statusNode.textContent = "Loaded data/data.json";
+
   GLOBAL_DATA.suites = [
     ...new Set(GLOBAL_DATA.data.passing_benchmarks.map((x) => x.suite_name)),
   ].sort();
   STATE.activeSuite = GLOBAL_DATA.suites[0] ?? null;
 
-  statusNode.textContent = "Loaded data/data.json";
-  renderSummary();
+  // Set up interactive elements
+  setupSuiteSelectors();
+  setupTimeDisplaySelector();
 
-  renderSuiteSelectors();
-  renderTable();
+  render();
+}
+
+function setupTimeDisplaySelector() {
+  for (const radio of document.querySelectorAll('input[name="time-display"]')) {
+    radio.addEventListener("change", () => {
+      if (radio.checked) {
+        STATE.timeDisplay = radio.value;
+        render();
+      }
+    });
+  }
+}
+
+function displayTime(rawValue) {
+  const ONE_MIN = 60000000;
+  const ONE_SEC = 1000000;
+  const ONE_MILLI = 1000;
+  if (STATE.timeDisplay === "raw") {
+    return `${rawValue} μs`;
+  } else {
+    console.assert(STATE.timeDisplay === "readable");
+    if (rawValue >= ONE_MIN) {
+      return `${(rawValue / ONE_MIN).toFixed(2)} min`;
+    } else if (rawValue >= ONE_SEC) {
+      return `${(rawValue / ONE_SEC).toFixed(2)} s`;
+    } else if (rawValue >= ONE_MILLI) {
+      return `${(rawValue / ONE_MILLI).toFixed(2)} ms`;
+    } else {
+      return `${rawValue} μs`;
+    }
+  }
 }
 
 function renderSummary() {
@@ -53,13 +87,13 @@ function renderSummary() {
   document.querySelector("#summary-text").textContent =
     `Passing Benchmarks: ${numPassing} | ` +
     `Failing Benchmarks: ${numFailing} | ` +
-    `Nightly time: ${totalTime} μs | ` +
-    `Rule running: ${ruleMicros} μs | ` +
-    `Extraction: ${extractMicros} μs | ` +
-    `Other: ${otherMicros} μs`;
+    `Nightly time: ${displayTime(totalTime)} | ` +
+    `Rule running: ${displayTime(ruleMicros)} | ` +
+    `Extraction: ${displayTime(extractMicros)} | ` +
+    `Other: ${displayTime(otherMicros)}`;
 }
 
-function renderSuiteSelectors() {
+function setupSuiteSelectors() {
   document.querySelector("#suite-tabs").innerHTML = GLOBAL_DATA.suites
     .map(
       (suite) =>
@@ -104,23 +138,22 @@ function renderTable() {
     <p>${benchmarks.length} benchmarks | ${totalTime} s</p>
   </div>`;
 
-  const columns = [
-    "Benchmark",
-    "Wall Time (μs)",
-    "Rules (μs)",
-    "Extraction (μs)",
-    "Other (μs)",
-  ];
+  const columns = ["Benchmark", "Wall Time", "Rules", "Extraction", "Other"];
 
   const rows = benchmarks.map((b) => ({
     Benchmark: b.benchmark_name,
-    "Wall Time (μs)": b.wall_time_micros,
-    "Rules (μs)": b.report.rule_micros,
-    "Extraction (μs)": b.report.extraction_micros,
-    "Other (μs)": b.report.other_micros,
+    "Wall Time": displayTime(b.wall_time_micros),
+    Rules: displayTime(b.report.rule_micros),
+    Extraction: displayTime(b.report.extraction_micros),
+    Other: displayTime(b.report.other_micros),
   }));
 
   const tableDiv = document.querySelector("#active-suite-table");
   tableDiv.innerHTML = "";
   tableDiv.appendChild(convertToTable(columns, rows));
+}
+
+function render() {
+  renderSummary();
+  renderTable();
 }

--- a/infra/nightly-resources/web/style.css
+++ b/infra/nightly-resources/web/style.css
@@ -12,6 +12,21 @@ body {
 .page {
   width: 100%;
   padding: 24px;
+  position: relative;
+}
+
+#time-display-selector {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  display: flex;
+  gap: 12px;
+  border: 1px solid #ccc;
+  padding: 8px 12px;
+}
+
+#time-display-selector legend {
+  padding: 0 4px;
 }
 
 h1 {

--- a/infra/nightly-resources/web/table.js
+++ b/infra/nightly-resources/web/table.js
@@ -14,10 +14,15 @@
  * Extra values are ignored. Missing values are displayed as `-` in the table
  * If empty, a table with only the header row will be returned
  *
+ * @param {Object} [displayFns]
+ * Optional map from column name -> formatter function (rawValue) => string.
+ * Sorting still uses the raw value from `rows`; rendering uses the formatted
+ * string. Columns not listed are rendered as-is.
+ *
  * @return An HTML <table> DOM element
  * Sortable by column, defaults to sorted by first column
  */
-export function convertToTable(columns, rows) {
+export function convertToTable(columns, rows, displayFns = {}) {
   const table = document.createElement("table");
 
   const STATE = {
@@ -83,7 +88,14 @@ export function convertToTable(columns, rows) {
       const tr = document.createElement("tr");
       for (const column of columns) {
         const td = document.createElement("td");
-        td.textContent = row[column] ?? "-"; // We want to leave 0 and "" intact, so don't use ||
+        const rawValue = row[column];
+        if (rawValue === undefined || rawValue === null) {
+          td.textContent = "-";
+        } else if (displayFns[column]) {
+          td.textContent = displayFns[column](rawValue);
+        } else {
+          td.textContent = rawValue;
+        }
         tr.appendChild(td);
       }
       tbody.appendChild(tr);

--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -28,19 +28,21 @@ def main(benchmark_dir):
   data_out_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 def run_command(cmd):
-  started = time.perf_counter()
+  started = time.perf_counter_ns()
   cmd_result = subprocess.run(
     cmd,
     cwd=POACH_ROOT,
     capture_output=True,
     text=True # decode stderr/stdout as string instead of raw bytes
   )
+  # Clock granularity is ~50-100 ns.
+  # Report as micros to avoid reporting false precision.
+  time_micros = (time.perf_counter_ns() - started) // 1000
   if cmd_result.returncode != 0:
-    time_seconds = time.perf_counter() - started
-    print(f"Command failed after {time_seconds:.2f}s: {' '.join(cmd)}", file=sys.stderr)
     return {
       "cmd": cmd,
-      "status": "error"
+      "status": "error",
+      "wall_time_micros": time_micros
     }
 
   report = json.loads(cmd_result.stderr)
@@ -49,30 +51,30 @@ def run_command(cmd):
     "cmd": " ".join(cmd),
     "status": "success",
     "report": summarize_report(report),
-    "wall_time_s": time.perf_counter() - started
+    "wall_time_micros": time_micros
   }
   
 def summarize_report(report):
   # aggregate timing steps by type
-  rule_ms = 0
-  extraction_ms = 0
-  other_ms = 0
-  total_ms = 0
+  rule_micros = 0
+  extraction_micros = 0
+  other_micros = 0
+  total_micros = 0
   for time_step in report["timings"]:
-    total_ms += time_step["total"]
+    total_micros += time_step["total"]
     if "running_rules" in time_step["tags"]:
-      rule_ms += time_step["total"]
+      rule_micros += time_step["total"]
     elif "extraction" in time_step["tags"]:
-      extraction_ms += time_step["total"]
+      extraction_micros += time_step["total"]
     else:
-      other_ms += time_step["total"]
+      other_micros += time_step["total"]
 
   # No sizes in vanilla egglog reports
 
   return {
-    "rule_ms": rule_ms,
-    "extraction_ms": extraction_ms,
-    "other_ms": other_ms,
+    "rule_micros": rule_micros,
+    "extraction_micros": extraction_micros,
+    "other_micros": other_micros,
     "timing_steps": len(report["timings"])
   }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -109,13 +109,13 @@ impl Display for TimingStep {
         writeln!(f, "timing:")?;
         writeln!(f, "  name: {}", self.name)?;
         writeln!(f, "  tags: {:?}", self.tags)?;
-        writeln!(f, "  total: {}", self.total.as_secs_f64())?;
+        writeln!(f, "  total: {}", self.total.as_micros())?;
         writeln!(
             f,
             "  breakdown: {:?}",
             self.breakdown
                 .iter()
-                .map(Duration::as_millis)
+                .map(Duration::as_micros)
                 .collect::<Vec<_>>()
         )?;
         Ok(())
@@ -126,6 +126,8 @@ fn serialize_duration_total<S>(total: &Duration, serializer: S) -> Result<S::Ok,
 where
     S: Serializer,
 {
+    // Clock granularity is ~50-100 ns.
+    // Serialize as micros to avoid reporting false precision.
     total.as_micros().serialize(serializer)
 }
 
@@ -133,8 +135,10 @@ fn serialize_duration_breakdown<S>(breakdown: &[Duration], serializer: S) -> Res
 where
     S: Serializer,
 {
-    let breakdown_millis: Vec<_> = breakdown.iter().map(Duration::as_micros).collect();
-    breakdown_millis.serialize(serializer)
+    // Clock granularity is ~50-100 ns.
+    // Serialize as micros to avoid reporting false precision.
+    let breakdown_micros: Vec<_> = breakdown.iter().map(Duration::as_micros).collect();
+    breakdown_micros.serialize(serializer)
 }
 
 fn write_metric_section<T>(f: &mut Formatter<'_>, title: &str, metrics: &[T]) -> fmt::Result

--- a/src/report.rs
+++ b/src/report.rs
@@ -28,7 +28,7 @@ pub struct RunReport {
 struct TimingStep {
     name: String,
     tags: Vec<String>,
-    #[serde(with = "serde_millis")]
+    #[serde(serialize_with = "serialize_duration_total")]
     total: Duration,
     #[serde(serialize_with = "serialize_duration_breakdown")]
     breakdown: Vec<Duration>,
@@ -122,11 +122,18 @@ impl Display for TimingStep {
     }
 }
 
+fn serialize_duration_total<S>(total: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    total.as_micros().serialize(serializer)
+}
+
 fn serialize_duration_breakdown<S>(breakdown: &[Duration], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    let breakdown_millis: Vec<_> = breakdown.iter().map(Duration::as_millis).collect();
+    let breakdown_millis: Vec<_> = breakdown.iter().map(Duration::as_micros).collect();
     breakdown_millis.serialize(serializer)
 }
 


### PR DESCRIPTION
- Measure time as precisely as possible using nanos
- Serialize as micros to avoid over-representing precision
- On the frontend, allow user to choose between displaying raw values (micros) and human readable values (micros, millis, seconds, or minutes depending on the value). Note that the correct unit for each value is chosen independently, so there can be different time units in a single column. For this reason, the unit is now shown in each cell, not the column header

Other ideas to consider in the future
- Enable displaying times as percentage of total time

<img width="1114" height="596" alt="image" src="https://github.com/user-attachments/assets/09b64e6b-cda1-4bbb-b9da-039de1b29735" />
