### PR TITLE
Runnable Nightly on main + Table Detail View

### DIFF
--- a/infra/nightly-resources/web/index.js
+++ b/infra/nightly-resources/web/index.js
@@ -22,7 +22,7 @@ async function load() {
   }
 
   GLOBAL_DATA.data = await response.json();
-  statusNode.textContent = "Loaded data/data.json";
+  statusNode.innerHTML = 'Loaded <a href="./data/data.json">data/data.json</a>';
 
   GLOBAL_DATA.suites = [
     ...new Set(GLOBAL_DATA.data.passing_benchmarks.map((x) => x.suite_name)),
@@ -68,29 +68,24 @@ function displayTime(rawValue) {
 }
 
 function renderSummary() {
-  let ruleMicros = 0;
-  let extractMicros = 0;
-  let otherMicros = 0;
+  let trainMicros = 0;
+  let serveMicros = 0;
 
-  for (const reportSummary of GLOBAL_DATA.data.passing_benchmarks) {
-    ruleMicros += reportSummary.report.rule_micros;
-    extractMicros += reportSummary.report.extraction_micros;
-    otherMicros += reportSummary.report.other_micros;
+  for (const b of GLOBAL_DATA.data.passing_benchmarks) {
+    trainMicros += b.train.wall_time_micros;
+    serveMicros += b.serve.wall_time_micros;
   }
 
   const numPassing = GLOBAL_DATA.data.passing_benchmarks.length;
   const numFailing = GLOBAL_DATA.data.failing_benchmarks.length;
-  const totalTime = GLOBAL_DATA.data.passing_benchmarks
-    .map((x) => x.wall_time_micros)
-    .reduce((a, b) => a + b, 0);
+  const totalTime = trainMicros + serveMicros;
 
   document.querySelector("#summary-text").textContent =
     `Passing Benchmarks: ${numPassing} | ` +
     `Failing Benchmarks: ${numFailing} | ` +
-    `Nightly time: ${displayTime(totalTime)} | ` +
-    `Rule running: ${displayTime(ruleMicros)} | ` +
-    `Extraction: ${displayTime(extractMicros)} | ` +
-    `Other: ${displayTime(otherMicros)}`;
+    `Total time: ${displayTime(totalTime)} | ` +
+    `Total train time: ${displayTime(trainMicros)} | ` +
+    `Total serve time: ${displayTime(serveMicros)}`;
 }
 
 function setupSuiteSelectors() {
@@ -129,7 +124,7 @@ function renderTable() {
     (x) => x.suite_name === STATE.activeSuite,
   );
   const totalTime = benchmarks
-    .map((x) => x.wall_time_micros)
+    .map((b) => b.train.wall_time_micros + b.serve.wall_time_micros)
     .reduce((a, b) => a + b, 0);
 
   document.querySelector("#active-suite-summary").innerHTML = `
@@ -138,26 +133,32 @@ function renderTable() {
     <p>${benchmarks.length} benchmarks | ${displayTime(totalTime)} </p>
   </div>`;
 
-  const columns = ["Benchmark", "Wall Time", "Rules", "Extraction", "Other"];
+  const columns = ["Benchmark", "Train Time", "Serve Time"];
 
   const rows = benchmarks.map((b) => ({
     Benchmark: b.benchmark_name,
-    "Wall Time": b.wall_time_micros,
-    Rules: b.report.rule_micros,
-    Extraction: b.report.extraction_micros,
-    Other: b.report.other_micros,
+    "Train Time": b.train.wall_time_micros,
+    "Serve Time": b.serve.wall_time_micros,
   }));
 
   const displayFns = {
-    "Wall Time": displayTime,
-    Rules: displayTime,
-    Extraction: displayTime,
-    Other: displayTime,
+    "Train Time": displayTime,
+    "Serve Time": displayTime,
   };
 
   const tableDiv = document.querySelector("#active-suite-table");
   tableDiv.innerHTML = "";
-  tableDiv.appendChild(convertToTable(columns, rows, displayFns));
+  tableDiv.appendChild(
+    convertToTable(columns, rows, displayFns, renderBenchmarkDetail),
+  );
+}
+
+function renderBenchmarkDetail(row) {
+  const elt = document.createElement("div");
+  elt.className = "benchmark-detail";
+  elt.innerText = `Details for ${row.Benchmark}`;
+
+  return elt;
 }
 
 function render() {

--- a/infra/nightly-resources/web/style.css
+++ b/infra/nightly-resources/web/style.css
@@ -44,10 +44,7 @@ h1 {
 
 #benchmarks {
   margin: 0 0 16px;
-}
-
-.suite {
-  margin: 0 0 24px;
+  overflow-x: auto;
 }
 
 .suite-tab {
@@ -65,18 +62,6 @@ h1 {
   background: #111;
   border-color: #111;
   color: #fff;
-}
-
-.suite-header {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 16px;
-  margin: 0 0 8px;
-}
-
-.suite-header p {
-  margin: 0;
 }
 
 h3 {
@@ -112,6 +97,16 @@ th:not(:first-child) {
   text-align: right;
 }
 
-#benchmarks {
-  overflow-x: auto;
+.expandable-row {
+  cursor: pointer;
+}
+
+.expandable-row:hover > td {
+  background: #f5f5f5;
+}
+
+.detail-row > td {
+  background: #fafafa;
+  padding: 16px 16px;
+  text-align: left;
 }

--- a/infra/nightly-resources/web/table.js
+++ b/infra/nightly-resources/web/table.js
@@ -19,10 +19,20 @@
  * Sorting still uses the raw value from `rows`; rendering uses the formatted
  * string. Columns not listed are rendered as-is.
  *
+ * @param {Function} [renderDetail]
+ * Optional callback (row) => HTMLElement. When provided, rows become
+ * clickable and toggle an inline detail row beneath them containing the
+ * element returned by the callback. Sorting collapses all open details.
+ *
  * @return An HTML <table> DOM element
  * Sortable by column, defaults to sorted by first column
  */
-export function convertToTable(columns, rows, displayFns = {}) {
+export function convertToTable(
+  columns,
+  rows,
+  displayFns = {},
+  renderDetail = null,
+) {
   const table = document.createElement("table");
 
   const STATE = {
@@ -98,6 +108,28 @@ export function convertToTable(columns, rows, displayFns = {}) {
         }
         tr.appendChild(td);
       }
+
+      if (renderDetail) {
+        tr.classList.add("expandable-row");
+        tr.addEventListener("click", () => {
+          const detailElt = tr.nextElementSibling;
+
+          if (detailElt && detailElt.classList.contains("detail-row")) {
+            // Detail is currently shown, this click should remove it.
+            detailElt.remove();
+          } else {
+            // Detail is currently closed, this click should show it.
+            const detailTr = document.createElement("tr");
+            detailTr.classList.add("detail-row");
+            const detailTd = document.createElement("td");
+            detailTd.colSpan = columns.length;
+            detailTd.appendChild(renderDetail(row));
+            detailTr.appendChild(detailTd);
+            tr.after(detailTr);
+          }
+        });
+      }
+
       tbody.appendChild(tr);
     }
     table.appendChild(tbody);

--- a/infra/nightly.py
+++ b/infra/nightly.py
@@ -14,8 +14,6 @@ NIGHTLY_DIR = POACH_ROOT / "nightly"
 POACH_BINARY = POACH_ROOT / "target" / "release" / "poach"
 
 def main(benchmark_dir):
-  print(benchmark_dir)
-
   (benchmark_results, failing_benchmarks) = run_benchmarks(benchmark_dir)
 
   data = {
@@ -27,7 +25,7 @@ def main(benchmark_dir):
   data_out_path.parent.mkdir(parents=True, exist_ok=True)
   data_out_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
-def run_command(cmd):
+def run_command(cmd, summarize_report):
   started = time.perf_counter_ns()
   cmd_result = subprocess.run(
     cmd,
@@ -53,72 +51,91 @@ def run_command(cmd):
     "report": summarize_report(report),
     "wall_time_micros": time_micros
   }
-  
-def summarize_report(report):
-  # aggregate timing steps by type
-  rule_micros = 0
-  extraction_micros = 0
-  other_micros = 0
-  total_micros = 0
-  for time_step in report["timings"]:
-    total_micros += time_step["total"]
-    if "running_rules" in time_step["tags"]:
-      rule_micros += time_step["total"]
-    elif "extraction" in time_step["tags"]:
-      extraction_micros += time_step["total"]
-    else:
-      other_micros += time_step["total"]
 
-  # Add size and other information to the report here
-
-  return {
-    "rule_micros": rule_micros,
-    "extraction_micros": extraction_micros,
-    "other_micros": other_micros,
-    "timing_steps": len(report["timings"])
+def summarize_train_report(report):
+  aggregated = {
+    "total_micros": 0
   }
+  
+  # Aggregate time of all steps
+  for time_step in report["timings"]:
+    aggregated["total_micros"] += time_step["total"]
+
+  # Rekey sizes
+  for size in report["sizes"]:
+    aggregated[size["name"]] = size["value"]
+
+  return aggregated
+
+def summarize_serve_report(report):
+  aggregated = {
+    "total_micros": 0
+  }
+  
+  # Aggregate time of all steps
+  for time_step in report["timings"]:
+    aggregated["total_micros"] += time_step["total"]
+
+  # Rekey sizes
+  for size in report["sizes"]:
+    aggregated[size["name"]] = size["value"]
+  
+  return aggregated
 
 def run_benchmarks(benchmark_dir):
-  report_dir = NIGHTLY_DIR / "reports"
-  report_dir.mkdir(parents=True, exist_ok=True)
-
   # Find benchmarks
   # benchmark_dir is the root of the benchmark directory 
   benchmarks = list(Path(benchmark_dir).rglob("train/*.egg"))
-  # For this treatment, we don't do anything at train time,
-  # we just use the train benchmarks at serve time
-
-  # TODO: invoke the poach commands appropriate for this branch (e.g.
-  # `poach train ...` and/or `poach serve ...`) for each benchmark file
-  # and append one result dict per command to `results`. Each result
-  # must include at least: "suite_name", "benchmark_name", "status",
-  # "wall_time_micros" (plus any branch-specific fields like "phase").
-
-  results = []
+  
+  reports = []
   failing_benchmarks = []
   for benchmark in benchmarks:
     relative_path = benchmark.relative_to(benchmark_dir)
     suite_name = str(relative_path.parent)
     benchmark_name = relative_path.name
-    command = [
+    
+    # We don't actually save the models, it gets overwritten each iter
+    # but that's okay because we don't need it after the serve command each iter
+    model_path = NIGHTLY_DIR / "model.model"
+
+    report = {
+      "benchmark_name": benchmark_name,
+      "suite_name": suite_name
+    }
+
+    # Train
+    train_command = [
+      str(POACH_BINARY),
+      "train",
+      "--debug",
+      str(benchmark),
+      str(model_path)
+    ]
+    train_result = run_command(train_command, summarize_train_report)
+    if train_result["status"] == "success":
+      report["train"] = train_result
+    else:
+      failing_benchmarks.append(relative_path)
+      continue
+
+    # Serve
+    serve_command = [
       str(POACH_BINARY),
       "serve",
       "--debug",
-      "EMPTY.MODEL",
+      str(model_path),
       "single",
       str(benchmark)
     ]
     
-    result = run_command(command)
-    result["benchmark_name"] = benchmark_name
-    result["suite_name"] = suite_name
-    if result["status"] == "success":
-      print(f"Success: {benchmark_name}")
-      results.append(result)
+    serve_result = run_command(serve_command, summarize_serve_report)
+    if serve_result["status"] == "success":
+      report["serve"] = serve_result
+      reports.append(report)
     else:
       failing_benchmarks.append(relative_path)
 
-  return (results, failing_benchmarks)
+  return (reports, failing_benchmarks)
 
 if __name__ == "__main__":
   if len(sys.argv) != 2:

--- a/src/poach.rs
+++ b/src/poach.rs
@@ -1,6 +1,10 @@
-use std::path::PathBuf;
+use std::{fs::File, path::PathBuf};
 
 use clap::{Args, Parser, Subcommand};
+use poach::{
+    EGraph,
+    report::{MetricValue, Reporter},
+};
 
 #[derive(Debug, Parser)]
 #[command(version, about)]
@@ -114,17 +118,39 @@ pub fn poach() {
             println!("test({:?})", arg);
         }
     }
-    // TODO handle report IO
 }
 
 fn train(arg: TrainArgs) {
-    println!("train({:?})", arg);
-    //TODO
+    // Extremely basic placeholder: Just creates an empty file
+    if arg.debug {
+        let mut reporter = Reporter::new();
+        let timer = reporter.new_timer("train".to_string(), vec![]);
+        let _ = File::create(arg.output_model_file.as_path());
+        reporter.record_timer(timer);
+
+        serde_json::to_writer(&mut std::io::stderr(), &reporter.build_report())
+            .expect("Failed to serialize report");
+    } else {
+        let _ = File::create(arg.output_model_file.as_path());
+    }
 }
 
 fn serve(arg: ServeArgs) {
-    println!("serve({:?})", arg);
-    //TODO
+    // Extremely basic placeholder: Just creates an empty egraph
+    if arg.debug {
+        let mut reporter = Reporter::new();
+        let timer = reporter.new_timer("serve".to_string(), vec![]);
+        let egraph = EGraph::default();
+        reporter.record_size(
+            "egraph size".to_string(),
+            MetricValue::Count(egraph.num_tuples() as u64),
+        );
+        reporter.record_timer(timer);
+        serde_json::to_writer(&mut std::io::stderr(), &reporter.build_report())
+            .expect("Failed to serialize report");
+    } else {
+        let _ = EGraph::default();
+    }
 }
 
 fn fine_tune(arg: FineTuneArgs) {


### PR DESCRIPTION
https://nightly.cs.washington.edu/reports/poach/1779147309:ajpal-update-nightly:24878daa/

My primary goal with this PR is to add detail views to the table so that you can click a row to expand it and show more information. However, it was a little tough to implement off of main directly, since there wasn't anything end-to-end runnable on main itself.

This PR puts in a very barebones implementation of `train` and `serve` so that we can make `nightly.py` more aligned with the algorithm branches. It actually runs train and serve on every benchmark and compiles all of the reports. Then on the frontend, we can show the full table and summary.

This PR should make it easier to implement features for nightly on `main` directly, since we now have a working end-to-end pipeline.


https://github.com/user-attachments/assets/06c6caca-30a0-48af-8ce9-9532fc72b847

